### PR TITLE
Provide version for ipython (addresses vagrant up failure)

### DIFF
--- a/tasks/versions.yml
+++ b/tasks/versions.yml
@@ -100,6 +100,7 @@
 
 - name: install python ipython package
   pip: name=ipython
+       version=5.8.0
        virtualenv=/opt/mutalyzer/versions/{{ mutalyzer_current }}/virtualenv
        state=present
   become_user: mutalyzer


### PR DESCRIPTION
Addresses failure to build using `vagrant up` (and would presumably be a problem in other systems using the ansible-rol-mutalyzer)